### PR TITLE
Expose number of bytes written via the mass storage gadget

### DIFF
--- a/drivers/usb/gadget/function/f_mass_storage.c
+++ b/drivers/usb/gadget/function/f_mass_storage.c
@@ -1983,7 +1983,6 @@ static int do_scsi_command(struct fsg_common *common)
 		break;
 
 	case WRITE_6:
-		printk(KERN_INFO "WRITE 6 - mason \n");
 		i = common->cmnd[4];
 		common->data_size_from_cmnd = (i == 0) ? 256 : i;
 		reply = check_command_size_in_blocks(common, 6,
@@ -1994,12 +1993,6 @@ static int do_scsi_command(struct fsg_common *common)
 			reply = do_write(common);
 		break;
 
-	/*
-	 * TODO: 
-	 * - Track the amount of data written for all the requests
-	 * - Track the number of write requests to compare against ioctl
-	 * 
-	 */
 	case WRITE_10:
 		printk(KERN_INFO "WRITE 10 - mason \n");
 		common->data_size_from_cmnd =
@@ -2018,7 +2011,6 @@ static int do_scsi_command(struct fsg_common *common)
 		break;
 
 	case WRITE_12:
-		printk(KERN_INFO "WRITE 12 - mason \n");
 		common->data_size_from_cmnd =
 				get_unaligned_be32(&common->cmnd[6]);
 		reply = check_command_size_in_blocks(common, 12,

--- a/drivers/usb/gadget/function/f_mass_storage.c
+++ b/drivers/usb/gadget/function/f_mass_storage.c
@@ -225,6 +225,21 @@ static struct usb_gadget_strings *fsg_strings_array[] = {
 
 /*-------------------------------------------------------------------------*/
 
+
+
+/*-------------------------------------------------------------------------*/
+
+/* Num bytes written while the driver has been active */
+static u32 num_bytes_written = 0; 
+
+u32 fsg_get_num_bytes_written(void) {
+	return num_bytes_written;
+}
+EXPORT_SYMBOL_GPL(fsg_get_num_bytes_written);
+
+
+/*-------------------------------------------------------------------------*/
+
 struct fsg_dev;
 struct fsg_common;
 
@@ -1833,12 +1848,15 @@ static int do_scsi_command(struct fsg_common *common)
 		break;
 
 	case ALLOW_MEDIUM_REMOVAL:
+		printk(KERN_INFO "ALLOW_MEDIUM_REMOVAL\n");
 		common->data_size_from_cmnd = 0;
 		reply = check_command(common, 6, DATA_DIR_NONE,
 				      (1<<4), 0,
 				      "PREVENT-ALLOW MEDIUM REMOVAL");
 		if (reply == 0)
 			reply = do_prevent_allow(common);
+		
+		printk(KERN_INFO "Can remove medium: %d\n", common->curlun->prevent_medium_removal);
 		break;
 
 	case READ_6:
@@ -1965,6 +1983,7 @@ static int do_scsi_command(struct fsg_common *common)
 		break;
 
 	case WRITE_6:
+		printk(KERN_INFO "WRITE 6 - mason \n");
 		i = common->cmnd[4];
 		common->data_size_from_cmnd = (i == 0) ? 256 : i;
 		reply = check_command_size_in_blocks(common, 6,
@@ -1975,18 +1994,31 @@ static int do_scsi_command(struct fsg_common *common)
 			reply = do_write(common);
 		break;
 
+	/*
+	 * TODO: 
+	 * - Track the amount of data written for all the requests
+	 * - Track the number of write requests to compare against ioctl
+	 * 
+	 */
 	case WRITE_10:
+		printk(KERN_INFO "WRITE 10 - mason \n");
 		common->data_size_from_cmnd =
 				get_unaligned_be16(&common->cmnd[7]);
 		reply = check_command_size_in_blocks(common, 10,
 				      DATA_DIR_FROM_HOST,
 				      (1<<1) | (0xf<<2) | (3<<7), 1,
 				      "WRITE(10)");
-		if (reply == 0)
+		if (reply == 0) {
+			printk(KERN_INFO "Size of data to write: %u\n", common->data_size_from_cmnd);
+			num_bytes_written += common->data_size_from_cmnd;
+			printk(KERN_INFO "Total bytes written: %u\n", num_bytes_written);
+
 			reply = do_write(common);
+		}
 		break;
 
 	case WRITE_12:
+		printk(KERN_INFO "WRITE 12 - mason \n");
 		common->data_size_from_cmnd =
 				get_unaligned_be32(&common->cmnd[6]);
 		reply = check_command_size_in_blocks(common, 12,

--- a/drivers/usb/gadget/function/f_mass_storage.h
+++ b/drivers/usb/gadget/function/f_mass_storage.h
@@ -141,4 +141,6 @@ void fsg_config_from_params(struct fsg_config *cfg,
 			    const struct fsg_module_parameters *params,
 			    unsigned int fsg_num_buffers);
 
+u32 fsg_get_num_bytes_written(void);
+
 #endif /* USB_F_MASS_STORAGE_H */

--- a/drivers/usb/gadget/legacy/mass_storage.c
+++ b/drivers/usb/gadget/legacy/mass_storage.c
@@ -27,10 +27,11 @@
 #include <linux/kernel.h>
 #include <linux/usb/ch9.h>
 #include <linux/module.h>
+#include <linux/kobject.h>
 
 /*-------------------------------------------------------------------------*/
 
-#define DRIVER_DESC		"Mass Storage Gadget"
+#define DRIVER_DESC		"Mass Storage Gadget - kaliber"
 #define DRIVER_VERSION		"2009/09/11"
 
 /*
@@ -43,6 +44,12 @@
 #define FSG_PRODUCT_ID	0xa4a5	/* Linux-USB File-backed Storage Gadget */
 
 #include "f_mass_storage.h"
+
+/*-------------------------------------------------------------------------*/
+
+static struct kobject *mass_storage_kobj;
+
+/*-------------------------------------------------------------------------*/
 
 /*-------------------------------------------------------------------------*/
 USB_GADGET_COMPOSITE_OPTIONS();
@@ -191,6 +198,9 @@ static int msg_bind(struct usb_composite_dev *cdev)
 	usb_composite_overwrite_options(cdev, &coverwrite);
 	dev_info(&cdev->gadget->dev,
 		 DRIVER_DESC ", version: " DRIVER_VERSION "\n");
+
+	mass_storage_kobj = kobject_create_and_add("mass_storage", NULL);
+
 	return 0;
 
 fail_otg_desc:
@@ -207,6 +217,8 @@ fail:
 
 static int msg_unbind(struct usb_composite_dev *cdev)
 {
+	u32 num_bytes = fsg_get_num_bytes_written();
+	printk(KERN_INFO "Num bytes written - mass_storage: %u \n", num_bytes);
 	if (!IS_ERR(f_msg))
 		usb_put_function(f_msg);
 
@@ -216,6 +228,8 @@ static int msg_unbind(struct usb_composite_dev *cdev)
 	kfree(otg_desc[0]);
 	otg_desc[0] = NULL;
 
+	kobject_put(mass_storage_kobj);
+	kobject_del(mass_storage_kobj);
 	return 0;
 }
 

--- a/drivers/usb/gadget/legacy/mass_storage.c
+++ b/drivers/usb/gadget/legacy/mass_storage.c
@@ -45,11 +45,6 @@
 
 #include "f_mass_storage.h"
 
-/*-------------------------------------------------------------------------*/
-
-static struct kobject *mass_storage_kobj;
-
-/*-------------------------------------------------------------------------*/
 
 /*-------------------------------------------------------------------------*/
 USB_GADGET_COMPOSITE_OPTIONS();
@@ -88,6 +83,17 @@ static struct usb_gadget_strings *dev_strings[] = {
 
 static struct usb_function_instance *fi_msg;
 static struct usb_function *f_msg;
+
+static struct kobject *mass_storage_kobj;
+static u32 bytes_written = 0;
+
+static ssize_t sysfs_show(struct kobject *kobj, struct kobj_attribute *attr, char *buf)
+{
+	bytes_written = fsg_get_num_bytes_written();
+	return sprintf(buf, "%u\n", bytes_written);
+}
+
+static struct kobj_attribute mass_storage_attribute = __ATTR(bytes_written, 0444, sysfs_show, NULL);
 
 /****************************** Configurations ******************************/
 
@@ -148,6 +154,7 @@ static int msg_bind(struct usb_composite_dev *cdev)
 	struct fsg_opts *opts;
 	struct fsg_config config;
 	int status;
+	int ret;
 
 	fi_msg = usb_get_function_instance("mass_storage");
 	if (IS_ERR(fi_msg))
@@ -199,7 +206,11 @@ static int msg_bind(struct usb_composite_dev *cdev)
 	dev_info(&cdev->gadget->dev,
 		 DRIVER_DESC ", version: " DRIVER_VERSION "\n");
 
-	mass_storage_kobj = kobject_create_and_add("mass_storage", NULL);
+	mass_storage_kobj = kobject_create_and_add("mass_storage_gadget", NULL);
+	ret = sysfs_create_file(mass_storage_kobj, &mass_storage_attribute.attr);
+	if (ret) {
+		printk(KERN_WARNING "Error creating sysfs file\n");
+	}
 
 	return 0;
 


### PR DESCRIPTION
Add a read-only sysfs entry that reports the bytes written over the USB mass storage gadget 